### PR TITLE
Next.lukasbradley

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,10 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
 
         <!-- library versions -->
         <assertj-core.version>2.7.0</assertj-core.version>
-        <joda-time.version>2.9.9</joda-time.version>
         <junit.version>4.11</junit.version>
         <logback.version>1.2.3</logback.version>
         <mockito.version>2.13.0</mockito.version>
@@ -83,12 +82,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${joda-time.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/vlkan/rfos/ByteCountingOutputStream.java
+++ b/src/main/java/com/vlkan/rfos/ByteCountingOutputStream.java
@@ -1,0 +1,48 @@
+package com.vlkan.rfos;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+class ByteCountingOutputStream extends OutputStream {
+
+    private final OutputStream parent;
+
+    private long size;
+
+    ByteCountingOutputStream(OutputStream parent, long size) {
+        this.parent = parent;
+        this.size = size;
+    }
+
+    OutputStream parent() {
+        return parent;
+    }
+
+    long size() {
+        return size;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        parent.write(b);
+        size += 1;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        parent.write(b);
+        size += b.length;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        parent.write(b, off, len);
+        size += len;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        parent.flush();
+    }
+
+}

--- a/src/main/java/com/vlkan/rfos/Clock.java
+++ b/src/main/java/com/vlkan/rfos/Clock.java
@@ -1,13 +1,23 @@
 package com.vlkan.rfos;
 
-import org.joda.time.LocalDateTime;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public interface Clock {
 
-    LocalDateTime now();
+    Instant now();
 
-    LocalDateTime midnight();
+    Instant midnight();
 
-    LocalDateTime sundayMidnight();
+    Instant sundayMidnight();
+
+    String ISO_LOCAL_DATE_TIME_WITH_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+    DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(ISO_LOCAL_DATE_TIME_WITH_MILLIS) ;
+
+    // TODO Should we move this to a util class? - Lukas Bradley
+    static Instant parse(String isoLocalDateTimeWithMillis) {
+        return Instant.from(FORMATTER.parse(isoLocalDateTimeWithMillis)) ;
+    }
 
 }

--- a/src/main/java/com/vlkan/rfos/LoggingRotationCallback.java
+++ b/src/main/java/com/vlkan/rfos/LoggingRotationCallback.java
@@ -27,11 +27,6 @@ public class LoggingRotationCallback implements RotationCallback {
     }
 
     @Override
-    public void onConflict(RotationPolicy policy, LocalDateTime dateTime) {
-        LOGGER.debug("rotation conflict {policy={}, dateTime={}}", policy, dateTime);
-    }
-
-    @Override
     public void onSuccess(RotationPolicy policy, LocalDateTime dateTime, File file) {
         LOGGER.debug("rotation success {policy={}, dateTime={}, file={}}", policy, dateTime, file);
     }

--- a/src/main/java/com/vlkan/rfos/LoggingRotationCallback.java
+++ b/src/main/java/com/vlkan/rfos/LoggingRotationCallback.java
@@ -1,11 +1,11 @@
 package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.time.Instant;
 
 public class LoggingRotationCallback implements RotationCallback {
 
@@ -22,17 +22,17 @@ public class LoggingRotationCallback implements RotationCallback {
     }
 
     @Override
-    public void onTrigger(RotationPolicy policy, LocalDateTime dateTime) {
+    public void onTrigger(RotationPolicy policy, Instant dateTime) {
         LOGGER.debug("rotation trigger {policy={}, dateTime={}}", policy, dateTime);
     }
 
     @Override
-    public void onSuccess(RotationPolicy policy, LocalDateTime dateTime, File file) {
+    public void onSuccess(RotationPolicy policy, Instant dateTime, File file) {
         LOGGER.debug("rotation success {policy={}, dateTime={}, file={}}", policy, dateTime, file);
     }
 
     @Override
-    public void onFailure(RotationPolicy policy, LocalDateTime dateTime, File file, Exception error) {
+    public void onFailure(RotationPolicy policy, Instant dateTime, File file, Exception error) {
         String message = String.format("rotation failure {policy=%s, dateTime=%s, file=%s}", policy, dateTime, file);
         LOGGER.error(message, error);
     }

--- a/src/main/java/com/vlkan/rfos/Rotatable.java
+++ b/src/main/java/com/vlkan/rfos/Rotatable.java
@@ -1,11 +1,12 @@
 package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
-import org.joda.time.LocalDateTime;
+
+import java.time.Instant;
 
 public interface Rotatable {
 
-    void rotate(RotationPolicy policy, LocalDateTime dateTime);
+    void rotate(RotationPolicy policy, Instant dateTime);
 
     RotationConfig getConfig();
 

--- a/src/main/java/com/vlkan/rfos/RotatingFileOutputStream.java
+++ b/src/main/java/com/vlkan/rfos/RotatingFileOutputStream.java
@@ -1,11 +1,11 @@
 package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.time.Instant;
 import java.util.*;
 import java.util.zip.GZIPOutputStream;
 
@@ -23,7 +23,7 @@ public class RotatingFileOutputStream extends OutputStream implements Rotatable 
 
     public RotatingFileOutputStream(RotationConfig config) {
         this.config = config;
-        this.runningThreads = Collections.synchronizedList(new LinkedList<Thread>());
+        this.runningThreads = Collections.synchronizedList(new LinkedList<>());
         this.writeSensitivePolicies = collectWriteSensitivePolicies(config.getPolicies());
         this.stream = open();
         startPolicies();
@@ -57,7 +57,7 @@ public class RotatingFileOutputStream extends OutputStream implements Rotatable 
     }
 
     @Override
-    public void rotate(RotationPolicy policy, LocalDateTime dateTime) {
+    public void rotate(RotationPolicy policy, Instant dateTime) {
         try {
             unsafeRotate(policy, dateTime);
         } catch (Exception error) {
@@ -67,7 +67,7 @@ public class RotatingFileOutputStream extends OutputStream implements Rotatable 
         }
     }
 
-    private void unsafeRotate(RotationPolicy policy, LocalDateTime dateTime) throws Exception {
+    private void unsafeRotate(RotationPolicy policy, Instant dateTime) throws Exception {
 
         File rotatedFile;
         synchronized (this) {
@@ -109,7 +109,7 @@ public class RotatingFileOutputStream extends OutputStream implements Rotatable 
 
     }
 
-    private void asyncCompress(final RotationPolicy policy, final LocalDateTime dateTime, final File rotatedFile, final RotationCallback callback) {
+    private void asyncCompress(final RotationPolicy policy, final Instant dateTime, final File rotatedFile, final RotationCallback callback) {
         String threadName = String.format("%s.compress(%s)", RotatingFileOutputStream.class.getSimpleName(), rotatedFile);
         Runnable threadTask = new Runnable() {
             @Override

--- a/src/main/java/com/vlkan/rfos/RotatingFilePattern.java
+++ b/src/main/java/com/vlkan/rfos/RotatingFilePattern.java
@@ -1,10 +1,8 @@
 package com.vlkan.rfos;
 
-import org.joda.time.LocalDateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 import java.io.File;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -22,7 +20,7 @@ public class RotatingFilePattern {
 
     private interface Field {
 
-        void render(StringBuilder builder, LocalDateTime dateTime);
+        void render(StringBuilder builder, Instant dateTime);
 
     }
 
@@ -35,7 +33,7 @@ public class RotatingFilePattern {
         }
 
         @Override
-        public void render(StringBuilder builder, LocalDateTime ignored) {
+        public void render(StringBuilder builder, Instant ignored) {
             builder.append(text);
         }
 
@@ -50,8 +48,8 @@ public class RotatingFilePattern {
         }
 
         @Override
-        public void render(StringBuilder builder, LocalDateTime dateTime) {
-            String formattedDateTime = dateTimeFormatter.print(dateTime);
+        public void render(StringBuilder builder, Instant dateTime) {
+            String formattedDateTime = dateTimeFormatter.format(dateTime);
             builder.append(formattedDateTime);
         }
 
@@ -118,7 +116,7 @@ public class RotatingFilePattern {
                                 String dateTimePattern = pattern.substring(blockStartIndex + 1, blockEndIndex);
                                 DateTimeFormatter dateTimeFormatter;
                                 try {
-                                    dateTimeFormatter = DateTimeFormat.forPattern(dateTimePattern).withLocale(locale);
+                                    dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern).withLocale(locale);
                                 } catch (Exception error) {
                                     String message = String.format(
                                             "invalid date time pattern (position=%d, pattern=%s, dateTimePattern=%s)",
@@ -165,7 +163,7 @@ public class RotatingFilePattern {
 
     }
 
-    public File create(LocalDateTime dateTime) {
+    public File create(Instant dateTime) {
         StringBuilder pathNameBuilder = new StringBuilder();
         for (Field field : fields) {
             field.render(pathNameBuilder, dateTime);

--- a/src/main/java/com/vlkan/rfos/RotationCallback.java
+++ b/src/main/java/com/vlkan/rfos/RotationCallback.java
@@ -9,8 +9,6 @@ public interface RotationCallback {
 
     void onTrigger(RotationPolicy policy, LocalDateTime dateTime);
 
-    void onConflict(RotationPolicy policy, LocalDateTime dateTime);
-
     void onSuccess(RotationPolicy policy, LocalDateTime dateTime, File file);
 
     void onFailure(RotationPolicy policy, LocalDateTime dateTime, File file, Exception error);

--- a/src/main/java/com/vlkan/rfos/RotationCallback.java
+++ b/src/main/java/com/vlkan/rfos/RotationCallback.java
@@ -1,16 +1,16 @@
 package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
-import org.joda.time.LocalDateTime;
 
 import java.io.File;
+import java.time.Instant;
 
 public interface RotationCallback {
 
-    void onTrigger(RotationPolicy policy, LocalDateTime dateTime);
+    void onTrigger(RotationPolicy policy, Instant dateTime);
 
-    void onSuccess(RotationPolicy policy, LocalDateTime dateTime, File file);
+    void onSuccess(RotationPolicy policy, Instant dateTime, File file);
 
-    void onFailure(RotationPolicy policy, LocalDateTime dateTime, File file, Exception error);
+    void onFailure(RotationPolicy policy, Instant dateTime, File file, Exception error);
 
 }

--- a/src/main/java/com/vlkan/rfos/RotationConfig.java
+++ b/src/main/java/com/vlkan/rfos/RotationConfig.java
@@ -26,6 +26,8 @@ public class RotationConfig {
 
     private final RotationCallback callback;
 
+    private final String encoding;
+
     private RotationConfig(Builder builder) {
         this.file = builder.file;
         this.filePattern = builder.filePattern;
@@ -35,6 +37,7 @@ public class RotationConfig {
         this.compress = builder.compress;
         this.clock = builder.clock;
         this.callback = builder.callback;
+        this.encoding = builder.encoding;
     }
 
     public File getFile() {
@@ -69,6 +72,8 @@ public class RotationConfig {
         return callback;
     }
 
+    public String getEncoding() { return encoding; }
+
     @Override
     public boolean equals(Object instance) {
         if (this == instance) return true;
@@ -81,12 +86,13 @@ public class RotationConfig {
                 Objects.equals(timer, that.timer) &&
                 Objects.equals(policies, that.policies) &&
                 Objects.equals(clock, that.clock) &&
-                Objects.equals(callback, that.callback);
+                Objects.equals(callback, that.callback) &&
+                Objects.equals(encoding, that.encoding);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(file, filePattern, timer, policies, append, compress, clock, callback);
+        return Objects.hash(file, filePattern, timer, policies, append, compress, clock, callback, encoding);
     }
 
     @Override
@@ -115,6 +121,8 @@ public class RotationConfig {
         private Clock clock = SystemClock.getInstance();
 
         private RotationCallback callback = LoggingRotationCallback.getInstance();
+
+        private String encoding = "UTF-8";
 
         private Builder() {
             // Do nothing.
@@ -178,6 +186,11 @@ public class RotationConfig {
             return this;
         }
 
+        public Builder encoding(String encoding) {
+            this.encoding = encoding;
+            return this;
+        }
+
         public RotationConfig build() {
             prepare();
             validate();
@@ -198,6 +211,7 @@ public class RotationConfig {
             }
             Objects.requireNonNull(clock, "clock");
             Objects.requireNonNull(callback, "callback");
+            Objects.requireNonNull(encoding, "encoding");
         }
 
     }

--- a/src/main/java/com/vlkan/rfos/RotationConfig.java
+++ b/src/main/java/com/vlkan/rfos/RotationConfig.java
@@ -7,8 +7,6 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class RotationConfig {
 
@@ -17,8 +15,6 @@ public class RotationConfig {
     private final RotatingFilePattern filePattern;
 
     private final Timer timer;
-
-    private final ReadWriteLock lock;
 
     private final Set<RotationPolicy> policies;
 
@@ -34,7 +30,6 @@ public class RotationConfig {
         this.file = builder.file;
         this.filePattern = builder.filePattern;
         this.timer = builder.timer;
-        this.lock = builder.lock;
         this.policies = builder.policies;
         this.append = builder.append;
         this.compress = builder.compress;
@@ -52,10 +47,6 @@ public class RotationConfig {
 
     public Timer getTimer() {
         return timer;
-    }
-
-    public ReadWriteLock getLock() {
-        return lock;
     }
 
     public Set<RotationPolicy> getPolicies() {
@@ -88,7 +79,6 @@ public class RotationConfig {
                 Objects.equals(file, that.file) &&
                 Objects.equals(filePattern, that.filePattern) &&
                 Objects.equals(timer, that.timer) &&
-                Objects.equals(lock, that.lock) &&
                 Objects.equals(policies, that.policies) &&
                 Objects.equals(clock, that.clock) &&
                 Objects.equals(callback, that.callback);
@@ -96,7 +86,7 @@ public class RotationConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(file, filePattern, timer, lock, policies, append, compress, clock, callback);
+        return Objects.hash(file, filePattern, timer, policies, append, compress, clock, callback);
     }
 
     @Override
@@ -115,8 +105,6 @@ public class RotationConfig {
         private RotatingFilePattern filePattern;
 
         private Timer timer;
-
-        private ReadWriteLock lock;
 
         private Set<RotationPolicy> policies;
 
@@ -154,11 +142,6 @@ public class RotationConfig {
 
         public Builder timer(Timer timer) {
             this.timer = timer;
-            return this;
-        }
-
-        public Builder lock(ReadWriteLock lock) {
-            this.lock = lock;
             return this;
         }
 
@@ -204,9 +187,6 @@ public class RotationConfig {
         private void prepare() {
             if (timer == null) {
                 timer = new Timer();
-            }
-            if (lock == null) {
-                lock = new ReentrantReadWriteLock();
             }
         }
 

--- a/src/main/java/com/vlkan/rfos/SystemClock.java
+++ b/src/main/java/com/vlkan/rfos/SystemClock.java
@@ -1,7 +1,9 @@
 package com.vlkan.rfos;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
 
 public class SystemClock implements Clock {
 
@@ -16,27 +18,30 @@ public class SystemClock implements Clock {
     }
 
     @Override
-    public LocalDateTime now() {
-        return LocalDateTime.now();
+    public Instant now() {
+        return Instant.now();
     }
 
     @Override
-    public LocalDateTime midnight() {
-        return currentDateTime().plusDays(1).withTimeAtStartOfDay().toLocalDateTime();
+    public Instant midnight() {
+        return midnight(currentDateTime().plus(Duration.ofDays(1)));
     }
 
     @Override
-    public LocalDateTime sundayMidnight() {
-        DateTime today = currentDateTime();
-        int dayIndex = today.getDayOfWeek() - 1;
+    public Instant sundayMidnight() {
+        Instant today = currentDateTime();
+        int dayIndex = today.get(ChronoField.DAY_OF_WEEK) - 1;
         int dayOffset = 7 - dayIndex;
-        DateTime monday = today.plusDays(dayOffset);
-        DateTime mondayStart = monday.withTimeAtStartOfDay();
-        return mondayStart.toLocalDateTime();
+        Instant monday = today.plus(Duration.ofDays(dayOffset));
+        return midnight(monday);
     }
 
-    protected DateTime currentDateTime() {
-        return DateTime.now();
+    protected Instant midnight(Instant instant) {
+        return instant.with(ChronoField.NANO_OF_DAY, 0) ;
+    }
+
+    protected Instant currentDateTime() {
+        return Instant.now();
     }
 
 }

--- a/src/main/java/com/vlkan/rfos/policy/DailyRotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/DailyRotationPolicy.java
@@ -1,9 +1,10 @@
 package com.vlkan.rfos.policy;
 
 import com.vlkan.rfos.Clock;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
 
 public class DailyRotationPolicy extends TimeBasedRotationPolicy {
 
@@ -20,7 +21,7 @@ public class DailyRotationPolicy extends TimeBasedRotationPolicy {
     }
 
     @Override
-    public LocalDateTime getTriggerDateTime(Clock clock) {
+    public Instant getTriggerDateTime(Clock clock) {
         return clock.midnight();
     }
 

--- a/src/main/java/com/vlkan/rfos/policy/RotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/RotationPolicy.java
@@ -6,4 +6,8 @@ public interface RotationPolicy {
 
     void start(Rotatable rotatable);
 
+    boolean isWriteSensitive();
+
+    void acceptWrite(long byteCount);
+
 }

--- a/src/main/java/com/vlkan/rfos/policy/SizeBasedRotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/SizeBasedRotationPolicy.java
@@ -2,12 +2,12 @@ package com.vlkan.rfos.policy;
 
 import com.vlkan.rfos.Rotatable;
 import com.vlkan.rfos.RotationConfig;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.TimerTask;
 
@@ -53,7 +53,7 @@ public class SizeBasedRotationPolicy implements RotationPolicy {
     @Override
     public void acceptWrite(long byteCount) {
         if (byteCount > maxByteCount) {
-            LocalDateTime now = rotatable.getConfig().getClock().now();
+            Instant now = rotatable.getConfig().getClock().now();
             rotate(now, byteCount, rotatable);
         }
     }
@@ -74,7 +74,7 @@ public class SizeBasedRotationPolicy implements RotationPolicy {
             public void run() {
 
                 // Get file size.
-                LocalDateTime now = config.getClock().now();
+                Instant now = config.getClock().now();
                 File file = config.getFile();
                 long byteCount;
                 try {
@@ -95,7 +95,7 @@ public class SizeBasedRotationPolicy implements RotationPolicy {
         };
     }
 
-    private void rotate(LocalDateTime now, long byteCount, Rotatable rotatable) {
+    private void rotate(Instant now, long byteCount, Rotatable rotatable) {
         LOGGER.debug("triggering {byteCount={}}", byteCount);
         rotatable.getConfig().getCallback().onTrigger(SizeBasedRotationPolicy.this, now);
         rotatable.rotate(SizeBasedRotationPolicy.this, now);

--- a/src/main/java/com/vlkan/rfos/policy/TimeBasedRotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/TimeBasedRotationPolicy.java
@@ -11,6 +11,14 @@ import java.util.TimerTask;
 public abstract class TimeBasedRotationPolicy implements RotationPolicy {
 
     @Override
+    public boolean isWriteSensitive() {
+        return false;
+    }
+
+    @Override
+    public void acceptWrite(long byteCount) {}
+
+    @Override
     public void start(Rotatable rotatable) {
         RotationConfig config = rotatable.getConfig();
         LocalDateTime triggerDateTime = getTriggerDateTime(config.getClock());

--- a/src/main/java/com/vlkan/rfos/policy/TimeBasedRotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/TimeBasedRotationPolicy.java
@@ -3,9 +3,10 @@ package com.vlkan.rfos.policy;
 import com.vlkan.rfos.Clock;
 import com.vlkan.rfos.Rotatable;
 import com.vlkan.rfos.RotationConfig;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 
+import java.time.Instant;
+import java.util.Date;
 import java.util.TimerTask;
 
 public abstract class TimeBasedRotationPolicy implements RotationPolicy {
@@ -21,12 +22,12 @@ public abstract class TimeBasedRotationPolicy implements RotationPolicy {
     @Override
     public void start(Rotatable rotatable) {
         RotationConfig config = rotatable.getConfig();
-        LocalDateTime triggerDateTime = getTriggerDateTime(config.getClock());
+        Instant triggerDateTime = getTriggerDateTime(config.getClock());
         TimerTask timerTask = createTimerTask(rotatable, triggerDateTime);
-        config.getTimer().schedule(timerTask, triggerDateTime.toDate());
+        config.getTimer().schedule(timerTask, Date.from(triggerDateTime));
     }
 
-    private TimerTask createTimerTask(final Rotatable rotatable, final LocalDateTime triggerDateTime) {
+    private TimerTask createTimerTask(final Rotatable rotatable, final Instant triggerDateTime) {
         final RotationConfig config = rotatable.getConfig();
         return new TimerTask() {
             @Override
@@ -39,7 +40,7 @@ public abstract class TimeBasedRotationPolicy implements RotationPolicy {
         };
     }
 
-    abstract public LocalDateTime getTriggerDateTime(Clock clock);
+    abstract public Instant getTriggerDateTime(Clock clock);
 
     abstract protected Logger getLogger();
 

--- a/src/main/java/com/vlkan/rfos/policy/WeeklyRotationPolicy.java
+++ b/src/main/java/com/vlkan/rfos/policy/WeeklyRotationPolicy.java
@@ -1,9 +1,10 @@
 package com.vlkan.rfos.policy;
 
 import com.vlkan.rfos.Clock;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
 
 public class WeeklyRotationPolicy extends TimeBasedRotationPolicy {
 
@@ -20,7 +21,7 @@ public class WeeklyRotationPolicy extends TimeBasedRotationPolicy {
     }
 
     @Override
-    public LocalDateTime getTriggerDateTime(Clock clock) {
+    public Instant getTriggerDateTime(Clock clock) {
         return clock.sundayMidnight();
     }
 

--- a/src/test/java/com/vlkan/rfos/ByteCountingOutputStreamTest.java
+++ b/src/test/java/com/vlkan/rfos/ByteCountingOutputStreamTest.java
@@ -1,0 +1,49 @@
+package com.vlkan.rfos;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Random;
+
+public class ByteCountingOutputStreamTest {
+
+    private static final Random RANDOM = new Random(0);
+
+    @Test
+    public void test() throws IOException {
+        for (int testIndex = 0; testIndex < 100; testIndex++) {
+            int textSize = RANDOM.nextInt(1024 * 1024);
+            String text = generateRandomString(textSize);
+            test(text);
+        }
+    }
+
+    private void test(String text) throws IOException {
+        String encoding = "UTF-8";
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            try (ByteCountingOutputStream byteCountingOutputStream = new ByteCountingOutputStream(byteArrayOutputStream, 0)) {
+                try (PrintStream printStream = new PrintStream(byteCountingOutputStream, false, encoding)) {
+                    printStream.print(text);
+                }
+                long actualSize = byteCountingOutputStream.size();
+                int expectedSize = text.getBytes(encoding).length;
+                Assertions.assertThat(actualSize).isEqualTo(expectedSize);
+            }
+        }
+    }
+
+    private static String generateRandomString(int length) {
+        int maxOffset = Character.MAX_VALUE - Character.MIN_VALUE;
+        StringBuilder builder = new StringBuilder();
+        while (length-- > 0) {
+            int offset = RANDOM.nextInt(maxOffset);
+            char c = (char) (Character.MIN_VALUE + offset);
+            builder.append(c);
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/test/java/com/vlkan/rfos/Rotatables.java
+++ b/src/test/java/com/vlkan/rfos/Rotatables.java
@@ -1,9 +1,9 @@
 package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
-import org.joda.time.LocalDateTime;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.concurrent.BlockingQueue;
 
 public enum Rotatables {;
@@ -20,7 +20,7 @@ public enum Rotatables {;
             }
 
             @Override
-            public void rotate(RotationPolicy policy, LocalDateTime dateTime) {
+            public void rotate(RotationPolicy policy, Instant dateTime) {
                 try {
                     rotationPolicies.put(policy);
                     rotationDateTimeTexts.put(dateTime.toString());

--- a/src/test/java/com/vlkan/rfos/RotatingFileOutputStreamTest.java
+++ b/src/test/java/com/vlkan/rfos/RotatingFileOutputStreamTest.java
@@ -2,13 +2,13 @@ package com.vlkan.rfos;
 
 import com.vlkan.rfos.policy.RotationPolicy;
 import com.vlkan.rfos.policy.SizeBasedRotationPolicy;
-import org.joda.time.LocalDateTime;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -41,12 +41,12 @@ public class RotatingFileOutputStreamTest {
         private final RotationCallback callback = new RotationCallback() {
 
             @Override
-            public void onTrigger(RotationPolicy policy, LocalDateTime dateTime) {
+            public void onTrigger(RotationPolicy policy, Instant dateTime) {
                 LOGGER.trace("onTrigger({}, {})", policy, dateTime);
             }
 
             @Override
-            public void onSuccess(RotationPolicy policy, LocalDateTime dateTime, File file) {
+            public void onSuccess(RotationPolicy policy, Instant dateTime, File file) {
                 LOGGER.trace("onSuccess({}, {}, {})", policy, dateTime, file);
                 try {
                     callbackSuccessPolicies.put(policy);
@@ -58,7 +58,7 @@ public class RotatingFileOutputStreamTest {
             }
 
             @Override
-            public void onFailure(RotationPolicy policy, LocalDateTime dateTime, File file, Exception error) {
+            public void onFailure(RotationPolicy policy, Instant dateTime, File file, Exception error) {
                 LOGGER.trace("onFailure({}, {}, {}, {})", policy, dateTime, file, error);
             }
 

--- a/src/test/java/com/vlkan/rfos/RotatingFilePatternTest.java
+++ b/src/test/java/com/vlkan/rfos/RotatingFilePatternTest.java
@@ -1,11 +1,11 @@
 package com.vlkan.rfos;
 
 import org.assertj.core.api.ThrowableAssert;
-import org.joda.time.LocalDateTime;
-import org.joda.time.format.DateTimeFormat;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -45,19 +45,19 @@ public class RotatingFilePatternTest {
 
     @Test
     public void test_valid_patterns() {
-        LocalDateTime dateTime = LocalDateTime.now();
+        Instant dateTime = Instant.now();
         Map<String, File> fileByPattern = new LinkedHashMap<>();
-        fileByPattern.put("%d{yyyy-mm-dd}", new File(DateTimeFormat.forPattern("yyyy-mm-dd").print(dateTime)));
-        fileByPattern.put("%d{yyyy-mm-dd}.log/foo%%", new File(String.format("%s.log/foo%%", DateTimeFormat.forPattern("yyyy-mm-dd").print(dateTime))));
-        fileByPattern.put("tmp/%d{yyyymmdd-HH}", new File(String.format("tmp/%s", DateTimeFormat.forPattern("yyyymmdd-HH").print(dateTime))));
-        fileByPattern.put("/tmp/%d{yyyymmdd-HH}", new File(String.format("/tmp/%s", DateTimeFormat.forPattern("yyyymmdd-HH").print(dateTime))));
+        fileByPattern.put("%d{yyyy-mm-dd}", new File(DateTimeFormatter.ofPattern("yyyy-mm-dd").format(dateTime)));
+        fileByPattern.put("%d{yyyy-mm-dd}.log/foo%%", new File(String.format("%s.log/foo%%", DateTimeFormatter.ofPattern("yyyy-mm-dd").format(dateTime))));
+        fileByPattern.put("tmp/%d{yyyymmdd-HH}", new File(String.format("tmp/%s", DateTimeFormatter.ofPattern("yyyymmdd-HH").format(dateTime))));
+        fileByPattern.put("/tmp/%d{yyyymmdd-HH}", new File(String.format("/tmp/%s", DateTimeFormatter.ofPattern("yyyymmdd-HH").format(dateTime))));
         fileByPattern.put(
                 "%d{yyyy}/%d{mm}/%d{yyyymmdd}.log",
                 new File(String.format(
                         "%s/%s/%s.log",
-                        DateTimeFormat.forPattern("yyyy").print(dateTime),
-                        DateTimeFormat.forPattern("mm").print(dateTime),
-                        DateTimeFormat.forPattern("yyyymmdd").print(dateTime))));
+                        DateTimeFormatter.ofPattern("yyyy").format(dateTime),
+                        DateTimeFormatter.ofPattern("mm").format(dateTime),
+                        DateTimeFormatter.ofPattern("yyyymmdd").format(dateTime))));
         for (String pattern : fileByPattern.keySet()) {
             File expectedFile = fileByPattern.get(pattern);
             File actualFile = new RotatingFilePattern(pattern).create(dateTime);

--- a/src/test/java/com/vlkan/rfos/SystemClockTest.java
+++ b/src/test/java/com/vlkan/rfos/SystemClockTest.java
@@ -1,9 +1,9 @@
 package com.vlkan.rfos;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDateTime;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,7 +17,7 @@ public class SystemClockTest {
 
         abstract protected Map<String, List<String>> getCurrentDateTimeTextsByExpectedDateTimeText();
 
-        abstract protected LocalDateTime getActualDateTime(Clock clock);
+        abstract protected Instant getActualDateTime(Clock clock);
 
         @Override
         public void run() {
@@ -31,14 +31,14 @@ public class SystemClockTest {
         }
 
         private void testDateTime(String currentDateTimeText, String expectedDateTimeText) {
-            final DateTime currentDateTime = DateTime.parse(currentDateTimeText);
+            final Instant currentDateTime = Clock.parse(currentDateTimeText);
             SystemClock clock = new SystemClock() {
                 @Override
-                protected DateTime currentDateTime() {
+                protected Instant currentDateTime() {
                     return currentDateTime;
                 }
             };
-            LocalDateTime actualDateTime = getActualDateTime(clock);
+            Instant actualDateTime = getActualDateTime(clock);
             String actualDateTimeText = actualDateTime.toString();
             assertThat(actualDateTimeText)
                     .isEqualTo(expectedDateTimeText)
@@ -80,7 +80,7 @@ public class SystemClockTest {
             }
 
             @Override
-            protected LocalDateTime getActualDateTime(Clock clock) {
+            protected Instant getActualDateTime(Clock clock) {
                 return clock.midnight();
             }
 
@@ -121,7 +121,7 @@ public class SystemClockTest {
             }
 
             @Override
-            protected LocalDateTime getActualDateTime(Clock clock) {
+            protected Instant getActualDateTime(Clock clock) {
                 return clock.sundayMidnight();
             }
 

--- a/src/test/java/com/vlkan/rfos/policy/DailyRotationPolicyTest.java
+++ b/src/test/java/com/vlkan/rfos/policy/DailyRotationPolicyTest.java
@@ -1,14 +1,10 @@
 package com.vlkan.rfos.policy;
 
-import com.vlkan.rfos.Clock;
-import com.vlkan.rfos.Rotatable;
-import com.vlkan.rfos.Rotatables;
-import com.vlkan.rfos.RotationConfig;
-import com.vlkan.rfos.RotatingFilePattern;
-import org.joda.time.LocalDateTime;
+import com.vlkan.rfos.*;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -33,7 +29,7 @@ public class DailyRotationPolicyTest {
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
-                        String timerDateTimeText = LocalDateTime.fromDateFields(date).toString();
+                        String timerDateTimeText = date.toInstant().toString();
                         try {
                             timerDateTimeTexts.put(timerDateTimeText);
                         } catch (InterruptedException ignored) {
@@ -48,7 +44,7 @@ public class DailyRotationPolicyTest {
         // Setup the 1st clock tick.
         Clock clock = mock(Clock.class);
         String midnight1Text = "2017-12-29T00:00:00.000";
-        when(clock.midnight()).thenReturn(LocalDateTime.parse(midnight1Text));
+        when(clock.midnight()).thenReturn(Instant.parse(midnight1Text));
 
         // Create the config.
         DailyRotationPolicy policy = DailyRotationPolicy.getInstance();
@@ -73,7 +69,7 @@ public class DailyRotationPolicyTest {
 
         // Setup the 2nd clock tick. (Will be consumed when we start draining from blocking queues.)
         String midnight2Text = "2017-12-30T00:00:00.000";
-        when(clock.midnight()).thenReturn(LocalDateTime.parse(midnight2Text));
+        when(clock.midnight()).thenReturn(Instant.parse(midnight2Text));
 
         // Consume the 1st blocking queue entries.
         String actualTimerDateTimeText1 = timerDateTimeTexts.poll(1, TimeUnit.SECONDS);

--- a/src/test/java/com/vlkan/rfos/policy/SizeBasedRotationPolicyTest.java
+++ b/src/test/java/com/vlkan/rfos/policy/SizeBasedRotationPolicyTest.java
@@ -1,14 +1,10 @@
 package com.vlkan.rfos.policy;
 
-import com.vlkan.rfos.Clock;
-import com.vlkan.rfos.Rotatable;
-import com.vlkan.rfos.Rotatables;
-import com.vlkan.rfos.RotationConfig;
-import com.vlkan.rfos.RotatingFilePattern;
-import org.joda.time.LocalDateTime;
+import com.vlkan.rfos.*;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
@@ -83,7 +79,7 @@ public class SizeBasedRotationPolicyTest {
 
         // Setup the 1st clock tick.
         String now1Text = "2017-12-31T00:00:00.000";
-        when(clock.now()).thenReturn(LocalDateTime.parse(now1Text));
+        when(clock.now()).thenReturn(Instant.parse(now1Text));
 
         // Setup the 1st file length probe.
         when(file.length()).thenReturn(1024L);


### PR DESCRIPTION
I hate GitHub.  I typed out a huge explantation, then it lost it on an attempted post.  URGH.

Please run the tests to see the issue it has.  It has to do with the Instant not having a valid timezone.  I feel the easy remedy is to utilize the system timezone, but I wanted more input from you.

Since Instant ISO parser doesn't include milliseconds, I added one on Clock.  I don't feel this is the right place for it, but I was unsure of your preference on utility classes/methods.

https://github.com/vy/rotating-fos/compare/next...lukasbradley:next.lukasbradley?expand=1#diff-910df41d04e6e046d6a6cbe17b9d482fR14

The pull request also includes the encoding change, because I did it before I sent other feedback.

