### PR TITLE
Correct typos in 'Usage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RotationConfig config = RotationConfig
         .build();
 
 try (RotatingFileOutputStream stream = new RotatingFileOutputStream(config)) {
-    stream.writer("Hello, world!".getBytes(StandardCharsets.UTF_8))
+    stream.write("Hello, world!".getBytes(StandardCharsets.UTF_8));
 }
 ```
 


### PR DESCRIPTION
Hi friend! This commit corrects two typos in line 37 of the README. Thank you!