### PR TITLE
Adding rollingFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ try (RotatingFileOutputStream stream = new RotatingFileOutputStream(config)) {
 | `executorService(ScheduledExecutorService)` | scheduler for time-based policies and compression tasks |
 | `append(boolean)` | append while opening the `file` (defaults to `true`) |
 | `compress(boolean)` | GZIP compression after rotation (defaults to `false`) |
+| `rollingFile(boolean)` | rolling file by indexes, based on SizeBasedRotationPolicy, similar to log4j RollingFileAppender. (defaults to `false`) |
 | `clock(Clock)` | clock for retrieving date and time (defaults to `SystemClock`) |
 | `callback(RotationCallback)` | rotation callback (defaults to `LoggingRotationCallback`) |
 
@@ -135,6 +136,7 @@ methods.
 - [Jonas (yawkat) Konrad](https://yawk.at/) (`RotatingFileOutputStream`
   thread-safety improvements)
 - [Lukas Bradley](https://github.com/lukasbradley/)
+- [Liran Mendelovich](https://github.com/liran2000/) (`rollingFile` enhancement)
 
 # License
 


### PR DESCRIPTION
Enhancement of rolling file by rollingFile configuration option.

Rolling file by indexes, based on SizeBasedRotationPolicy, similar to log4j RollingFileAppender (defaults to `false`).

Algorithm Implementation is taken and edited to fit from log4j [RollingFileAppender](https://github.com/innoq/log4j/blob/master/src/main/java/org/apache/log4j/RollingFileAppender.java#L127).

Backward compatible:
All unit tests are passing. Existing options and implementations remain untouched.

rollingFile enhancement is fully covered in a new unit test, which prints more than the max data, then validates that all backup indexes files exists, and do a sample test on the byte content of the files.

